### PR TITLE
Graceful ElevenLabs error handling with browser TTS fallback + exponential backoff retries

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,8 @@
             <div id="current-speaking" class="current-speaking"></div>
         </div>
 
+        <div id="notifications" class="notifications"></div>
+
         <div class="chat-display">
             <h3>Recent Messages</h3>
             <div id="chat-messages" class="messages"></div>

--- a/styles.css
+++ b/styles.css
@@ -390,6 +390,31 @@ button:hover {
     }
 }
 
+/* Notifications */
+.notifications {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1000;
+}
+
+.notification {
+    background: rgba(0,0,0,0.85);
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 14px;
+    box-shadow: 0 6px 16px rgba(0,0,0,0.25);
+    max-width: 320px;
+}
+
+.notification.error { background: #dc3545; }
+.notification.warn { background: #ffc107; color: #212529; }
+.notification.info { background: #17a2b8; }
+
 /* Scrollbar styling */
 .messages::-webkit-scrollbar,
 .queue::-webkit-scrollbar {


### PR DESCRIPTION
Summary
- Show non-blocking notifications for ElevenLabs API errors so TTS is not interrupted
- Automatically fall back to browser TTS when ElevenLabs is unavailable
- Add exponential backoff with jitter for periodic retries (base 5s, capped at 5 minutes)
- Recover automatically when ElevenLabs responds successfully again and notify user
- Re-enable ElevenLabs and reset backoff when API key changes

Details
- UI: Added a notifications container and simple toast styling to surface errors/warnings/information without blocking speech
- Logic: On ElevenLabs failure, disable ElevenLabs for the session and schedule a retry using exponential backoff; continue speaking via browser TTS. On success, reset backoff and show a restoration message once
- Auth handling: 401 responses set an auth error flag to prevent repeated attempts until the user corrects the API key. Changing the API key clears the auth flag and resets backoff

Files changed
- index.html: add notifications container
- styles.css: add notification styles
- script.js: add error handling, fallback, backoff scheduling, success recovery, and API key change handling

Notes
- No changes to build/infra; pure client-side behavior improvements
- No PR template found in the repository; following standard summary/details format

Testing
- With invalid API key: first failure shows red toast with status, switches to browser TTS; retry is scheduled with exponential backoff. After delay, the next queue item tries ElevenLabs again
- With no key: browser TTS is used without errors
- After fixing API key: ElevenLabs re-enables, backoff is reset, and future items use ElevenLabs again


@lyndsysimon can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a487c38fa2ef4c249875cec21ed70d3e)